### PR TITLE
Upgrade gsl version to 1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,9 +330,9 @@ Please take a moment to [give me your feedback on the gem](https://docs.google.c
         sha1 '210af9366485f149140973700d90dc93a4b6213e'
     to:
 
-        url 'http://ftpmirror.gnu.org/gsl/gsl-1.14.tar.gz'
-        mirror 'http://ftp.gnu.org/gnu/gsl/gsl-1.14.tar.gz'
-        sha1 'e1a600e4fe359692e6f0e28b7e12a96681efbe52'
+        url 'http://ftpmirror.gnu.org/gsl/gsl-1.15.tar.gz'
+        mirror 'http://ftp.gnu.org/gnu/gsl/gsl-1.15.tar.gz'
+        sha1 'd914f84b39a5274b0a589d9b83a66f44cd17ca8e'
 - Install GSL
 
         brew install gsl


### PR DESCRIPTION
I noticed Ubuntu 13.04 version was 1.15, so I tried it on OSX and it worked as well.

@jimlindstrom, do all of your tests pass? I get:

```
415 examples, 24 failures, 12 pending
```
