### PR TITLE
Add support for travis-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *swp
+.ruby-version
 pkg/
 Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+rvm:
+  - '1.9.3'
+  - '2.0.0'
+before_install:
+  - cat /etc/*release*
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq imagemagick libmagickwand-dev libgsl0-dev
+  - gem update --system

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/jimlindstrom/FinModeling.png?branch=master)](https://travis-ci.org/jimlindstrom/FinModeling)
+
 ## Overview
 
 FinModeling is an equity valuation framework. It can retrieve and parse [XBRL](http://en.wikipedia.org/wiki/XBRL)-based filings from SEC Edgar. As of March 2013, it can successfully parse the last 2-5 years of quarterly and annual filings from 52% of the Nasdaq 100 companies. (The remainder fail due to a long-tail distribution of filing formatting peculiarities for which I haven't yet written special-case code to handle.)


### PR DESCRIPTION
Hi Jim,

This PR adds support for http://travis-ci.org to automatically build master and show the status on the main project page. I had added it to my local copy to make sure my spec failures weren't local.

The steps on the link below will need to be completed before travis-ci will work fully.

http://about.travis-ci.org/docs/user/getting-started/

Thanks!
Greg
